### PR TITLE
Allow an API to send extra headers to a proxy target

### DIFF
--- a/docs/API-Specification.md
+++ b/docs/API-Specification.md
@@ -47,6 +47,9 @@ Content-Type: application/json; charset=utf-8
     "target": "{target_url}",
     "append": {
         "{append_property}": "{append_value}"
+    },
+    "set_headers": {
+        "{header_name}": "{header_value}"
     }
 }
 ```
@@ -72,5 +75,7 @@ In these responses:
 `{redirect_type}` is the redirect status code to use when Thundermole redirects. It is optional, and will default to `301`. This should be a number, not a string, and only `301`, `302`, `303`, and `307` values are accepted.
 
 The `append` property should be an object that will be passed onto the target application in the `X-Proxy-Appended-Data` header, serialized as JSON. Append data is only used when proxying, not redirecting.
+
+The `set_headers` property is optional, and should be either `undefined` or an object that will be passed onto the target application as additional headers. Set headers data is only used when proxying, not redirecting.
 
 Any extra headers or body properties will be ignored.

--- a/lib/api.js
+++ b/lib/api.js
@@ -51,6 +51,9 @@ function getApiResponseErrors (apiRequest, apiResponse, apiResponseBody) {
 	if (apiResponseBody.redirect_type && [301, 302, 303, 307].indexOf(apiResponseBody.redirect_type) === -1) {
 		return new Error('API (' + apiRequest.url + ') response redirect_type property is invalid. Should be 301, 302, 303, or 307');
 	}
+	if (typeof apiResponseBody.set_headers !== 'undefined' && (apiResponseBody.set_headers === null || typeof apiResponseBody.set_headers !== 'object')) {
+		return new Error('API (' + apiRequest.url + ') response set_headers property is not an object');
+	}
 	return null;
 }
 

--- a/lib/thundermole.js
+++ b/lib/thundermole.js
@@ -136,6 +136,7 @@ function handleUserRequest (mole, options, request, response) {
 		mole.logger.info('Proxying request %s to %s', request.url, apiResponse.target);
 		mole.proxy.web(request, response, {
 			append: apiResponse.append,
+			set_headers: apiResponse.set_headers,
 			target: apiResponse.target
 		});
 	});
@@ -147,6 +148,17 @@ function augmentProxyRequest (options, proxyRequest, request, response, proxyOpt
 	}
 	proxyRequest.removeHeader(options.appendHeader);
 	proxyRequest.setHeader(options.appendHeader, JSON.stringify(proxyOptions.append || {}));
+	if (proxyOptions.set_headers) {
+		setProxyRequestHeaders(proxyRequest, proxyOptions.set_headers);
+	}
+}
+
+function setProxyRequestHeaders (proxyRequest, headers) {
+	for (var headerName in headers) {
+		if (headers.hasOwnProperty(headerName)) {
+			proxyRequest.setHeader(headerName, headers[headerName]);
+		}
+	}
 }
 
 function handleError (error, request, response) {

--- a/test/integration/mock/api-default.js
+++ b/test/integration/mock/api-default.js
@@ -44,6 +44,18 @@ function startApiDefault (testAppsConfig, done) {
 			}));
 		},
 
+		'/api/set-headers': function (request, response) {
+			response.writeHead(200);
+			response.end(JSON.stringify({
+				target: testAppsConfig.addresses.backendDefault,
+				append: {},
+				set_headers: {
+					'X-Foo': 'bar',
+					'X-Bar': 'baz'
+				}
+			}));
+		},
+
 		'/api/redirect': function (request, response) {
 			response.writeHead(200);
 			response.end(JSON.stringify({

--- a/test/integration/mock/backend-default.js
+++ b/test/integration/mock/backend-default.js
@@ -36,6 +36,11 @@ function startBackendDefault (testAppsConfig, done) {
 			response.end('Hello From Backend Default!');
 		},
 
+		'/set-headers': function (request, response) {
+			response.writeHead(200);
+			response.end('Hello with added headers!');
+		},
+
 		'/regexp': function (request, response) {
 			response.writeHead(200);
 			response.end('RegExp 1');

--- a/test/integration/mock/mole.js
+++ b/test/integration/mock/mole.js
@@ -26,6 +26,7 @@ function startMole (testAppsConfig, done) {
 			incorrect: testAppsConfig.addresses.apiDefault + '/api/incorrect',
 			error: testAppsConfig.addresses.apiDefault + '/api/error',
 			notfound: testAppsConfig.addresses.apiDefault + '/api/notfound',
+			'set-headers': testAppsConfig.addresses.apiDefault + '/api/set-headers',
 			redirect: testAppsConfig.addresses.apiDefault + '/api/redirect',
 			'/regexp/i': testAppsConfig.addresses.apiDefault + '/api/regexp',
 			default: testAppsConfig.addresses.apiDefault + '/api/routing'

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -114,6 +114,24 @@ describe('Thundermole ➞ Default API ➞ Default Backend', function () {
 
 	});
 
+	describeRequest('GET', '/set-headers', null, function () {
+
+		it('should respond with a 200 status', function () {
+			assert.strictEqual(this.lastResponse.statusCode, 200);
+		});
+
+		it('should respond with the expected body', function () {
+			assert.strictEqual(this.lastResponseBody, 'Hello with added headers!');
+		});
+
+		it('should send the expected additional headers to the back-end', function () {
+			var backendRequest = this.testApps.backendDefault.lastRequest;
+			assert.strictEqual(backendRequest.headers['x-foo'], 'bar');
+			assert.strictEqual(backendRequest.headers['x-bar'], 'baz');
+		});
+
+	});
+
 	describeRequest('GET', '/400', null, function () {
 
 		it('should respond with a 400 status', function () {

--- a/test/unit/lib/api.js
+++ b/test/unit/lib/api.js
@@ -101,6 +101,13 @@ describe('lib/api', function () {
 				assert.isTrue(callback.withArgs(null, apiResponseBody).calledOnce);
 			});
 
+			it('should call the callback with no error and the response body as an object if `set_headers` is present and valid', function () {
+				apiResponseBody.set_headers = {};
+				responseHandler(null, apiResponse, apiResponseBody);
+				assert.isTrue(callback.calledOnce);
+				assert.isTrue(callback.withArgs(null, apiResponseBody).calledOnce);
+			});
+
 			it('should call the callback with an error if error is non-null', function () {
 				var error = new Error();
 				responseHandler(error, apiResponse, apiResponseBody);
@@ -140,6 +147,14 @@ describe('lib/api', function () {
 				assert.isTrue(callback.calledOnce);
 				assert.isTrue(callback.withArgs(new Error(), apiResponseBody).calledOnce);
 				assert.strictEqual(callback.firstCall.args[0].message, 'API (foo) response redirect_type property is invalid. Should be 301, 302, 303, or 307');
+			});
+
+			it('should call the callback with an error if the `set_headers` property is invalid', function () {
+				apiResponseBody.set_headers = null;
+				responseHandler(null, apiResponse, apiResponseBody);
+				assert.isTrue(callback.calledOnce);
+				assert.isTrue(callback.withArgs(new Error(), apiResponseBody).calledOnce);
+				assert.strictEqual(callback.firstCall.args[0].message, 'API (foo) response set_headers property is not an object');
 			});
 
 		});


### PR DESCRIPTION
This adds the behaviour outlined in #37, allowing an API to specify additional headers that should be added to the user request when proxying.

@dazoakley: fancy reviewing?