### PR TITLE
Include any headers set by the API call in redirects

### DIFF
--- a/lib/thundermole.js
+++ b/lib/thundermole.js
@@ -136,9 +136,10 @@ function handleUserRequest (mole, options, request, response) {
 				apiResponse.redirect,
 				(apiResponse.redirect_type || httpStatus.MOVED_PERMANENTLY)
 			);
-			response.writeHead((apiResponse.redirect_type || httpStatus.MOVED_PERMANENTLY), {
-				Location: apiResponse.redirect
-			});
+			response.writeHead(
+				(apiResponse.redirect_type || httpStatus.MOVED_PERMANENTLY),
+				apiRedirectHeaders(apiResponse)
+			);
 			return response.end();
 		}
 		mole.logger.info('Proxying request %s to %s', request.url, apiResponse.target);
@@ -148,6 +149,10 @@ function handleUserRequest (mole, options, request, response) {
 			target: apiResponse.target
 		});
 	});
+}
+
+function apiRedirectHeaders (apiResponse) {
+	return _.extend({Location: apiResponse.redirect}, apiResponse.set_headers || {});
 }
 
 function augmentProxyRequest (options, proxyRequest, request, response, proxyOptions) {

--- a/test/unit/lib/thundermole.js
+++ b/test/unit/lib/thundermole.js
@@ -453,6 +453,7 @@ describe('lib/thundermole', function () {
 					beforeEach(function () {
 						apiResponse = {
 							redirect: 'foo-redirect',
+							set_headers: {foo: 'bar'},
 							redirect_type: 303
 						};
 						apiResponseHandler(null, apiResponse);
@@ -477,6 +478,19 @@ describe('lib/thundermole', function () {
 						assert.isTrue(response.writeHead.withArgs(301).calledOnce);
 						assert.isObject(response.writeHead.firstCall.args[1]);
 						assert.strictEqual(response.writeHead.firstCall.args[1].Location, 'foo-redirect');
+						assert.isTrue(response.end.calledOnce);
+					});
+
+					it('should pass the `set_headers` API repsonse on with the redirect', function () {
+						underscore.extend.returnsArg(1);
+						response.writeHead.reset();
+						response.end.reset();
+						apiResponseHandler(null, apiResponse);
+						assert.strictEqual(underscore.extend.firstCall.args[0].Location, 'foo-redirect');
+						assert.strictEqual(underscore.extend.firstCall.args[1].foo, 'bar');
+						assert.isTrue(response.writeHead.withArgs(303).calledOnce);
+						assert.isObject(response.writeHead.firstCall.args[1]);
+						assert.strictEqual(response.writeHead.firstCall.args[1].foo, 'bar');
 						assert.isTrue(response.end.calledOnce);
 					});
 

--- a/test/unit/mock/underscore.js
+++ b/test/unit/mock/underscore.js
@@ -18,5 +18,6 @@
 var sinon = require('sinon');
 
 module.exports = {
-	defaults: sinon.stub().returnsArg(1)
+	defaults: sinon.stub().returnsArg(1),
+	extend: sinon.stub().returnsArg(0)
 };


### PR DESCRIPTION
We have a case where the API call made by thundermole returns cookies in set_headers (to make the decision of the API call sticky for the user). These cookies are set fine where the response ends up being proxied to a backend, but get discarded if the response results in a redirect.