### PR TITLE
Add snyk to build and make npm scripts consistent

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+ignore: {}
+patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,9 @@ before_install:
 
 # Build script
 script:
-  - 'if [ $LINT ]; then make lint; fi'
-  - 'if [ ! $LINT ]; then make test-coverage; fi'
+  - 'if [ $LINT ]; then npm run lint; fi'
+  - 'if [ ! $LINT ]; then npm run test; fi'
+
+# Updates the dashboard after a successful deployment
+after_success:
+  - snyk monitor --org=springernature

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "scripts": {
     "start": "./bin/thundermole",
-    "test": "make ci"
+    "lint": "make lint",
+    "test": "snyk test && make ci"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "mocha": "^3.5.0",
     "mockery": "^1.7.0",
     "proclaim": "^3.4.5",
-    "sinon": "^1.0.0"
+    "sinon": "^1.0.0",
+    "snyk": "^1.38.1"
   },
   "main": "./lib/thundermole.js",
   "bin": {


### PR DESCRIPTION
This allows Snyk to run cleanly from the build process in Travis, and trigger a `snyk monitor` after a successful deployment.